### PR TITLE
Fix lovely injection that applied twice

### DIFF
--- a/SDM_0's Stuff/lovely.toml
+++ b/SDM_0's Stuff/lovely.toml
@@ -5,17 +5,20 @@ priority = 0
 
 
 # sdm_adding_card context
-
+# regex also has Talisman compat
 [[patches]]
-[patches.pattern]
+[patches.regex]
 target = "card.lua"
-pattern = "if self.edition and self.edition.negative then"
-position = "before"
+pattern = '''
+[\t ]*function Card:add_to_deck[\s\S]*?
+(?<indent>[\t ]*)if G\.GAME\.blind.*then G\.E_MANAGER:add_event\(Event\(\{ func = function\(\) G\.GAME\.blind:set_blind\(nil, true, nil\); return true end \}\)\) end\n'''
+position = "after"
 payload = """
 if G.jokers and #G.jokers.cards > 0 then
     for i = 1, #G.jokers.cards do
         G.jokers.cards[i]:calculate_joker({sdm_adding_card = true, card = self})
     end
 end
+
 """
-match_indent = true
+line_prepend = '$indent'


### PR DESCRIPTION
Reopening this PR, this patch seems to be more robust.

The context fires at the right time, so it sees changes to number of joker/consumable slots.